### PR TITLE
Use TokenStorageInterface

### DIFF
--- a/src/EventListener/DataContainer/ShortlinkPermissionListener.php
+++ b/src/EventListener/DataContainer/ShortlinkPermissionListener.php
@@ -8,18 +8,18 @@ use Contao\Backend;
 use Contao\BackendUser;
 use Contao\Image;
 use Contao\StringUtil;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class ShortlinkPermissionListener
 {
     private const TABLE = 'tl_terminal42_shortlink';
 
     /**
-     * @var TokenStorage
+     * @var TokenStorageInterface
      */
     private $tokenStorage;
 
-    public function __construct(TokenStorage $tokenStorage)
+    public function __construct(TokenStorageInterface $tokenStorage)
     {
         $this->tokenStorage = $tokenStorage;
     }


### PR DESCRIPTION
Fixes type error

> Argument 1 passed to Terminal42\ShortlinkBundle\EventListener\DataContainer\ShortlinkPermissionListener::__construct() must be an instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage, instance of Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorage given, 

Error ocurred in Contao 4.9