### PR TITLE
Fixes PHP 8 compatibility by allowing hashids/hashids in version 4.1 (fixes #14)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": "^7.4 || ^8.0",
         "contao/core-bundle": "^4.9",
         "codefog/contao-haste": "^4.20",
-        "hashids/hashids": "^3.0"
+        "hashids/hashids": "^3.0 || ^4.1"
     },
     "require-dev": {
         "contao/manager-plugin": "^2.0",


### PR DESCRIPTION
Version 3.0 of hashids/hashids is not compatible to PHP 8. Allowing hashids/hashids 4.1 will allow the installation on PHP 8