### PR TITLE
Change tl_terminal42_shortlink_log.browser to text

### DIFF
--- a/src/Entity/ShortlinkLog.php
+++ b/src/Entity/ShortlinkLog.php
@@ -31,7 +31,7 @@ class ShortlinkLog
     /**
      * @var string
      *
-     * @ORM\Column(type="string", nullable=false)
+     * @ORM\Column(type="text", nullable=true, length=Doctrine\DBAL\Platforms\MySqlPlatform::LENGTH_LIMIT_TEXT)
      */
     private $browser;
 

--- a/src/Entity/ShortlinkLog.php
+++ b/src/Entity/ShortlinkLog.php
@@ -31,7 +31,7 @@ class ShortlinkLog
     /**
      * @var string
      *
-     * @ORM\Column(type="text", nullable=true, length=Doctrine\DBAL\Platforms\MySqlPlatform::LENGTH_LIMIT_TEXT)
+     * @ORM\Column(type="text", nullable=true, length=65535)
      */
     private $browser;
 


### PR DESCRIPTION
Fixes the following error:

```
Uncaught PHP Exception Doctrine\DBAL\Exception\DriverException: "An exception occurred while executing 'INSERT INTO tl_terminal42_shortlink_log (tstamp, browser, ip, pid) VALUES (?, ?, ?, ?)' with params [1648223659, "Mozilla\/5.0 (iPhone; CPU iPhone OS 15_4 like Mac OS X) AppleWebKit\/605.1.15 (KHTML, like Gecko) Mobile\/15E148 LightSpeed [FBAN\/MessengerLiteForiOS;FBAV\/…;FBBV\/…;FBDV\/iPhone11,8;FBMD\/iPhone;FBSN\/iOS;FBSV\/15.4;FBSS\/2;FBCR\/;FBID\/phone;FBLC\/de;FBOP\/0]", null, 89]:  SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'browser' at row 1"
```

Happens when you open a shortlink from the Facebook messenger for example (causes a really long user-agent). Alternatively we could shorten the string to 255 characters in the constructor of `ShortlinkLog`, wdyt?