### PR TITLE
Updates for Contao 5.3 and Rector updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": "^8.1",
         "composer-runtime-api": "^2.0",
         "composer/semver": "*",
-        "contao/core-bundle": "^5.3",
+        "contao/core-bundle": "^4.13 || ^5.0",
         "hashids/hashids": "^3.0 || ^4.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
         "source": "https://github.com/terminal42/contao-shortlink"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "composer-runtime-api": "^2.0",
         "composer/semver": "*",
-        "contao/core-bundle": "^4.9",
+        "contao/core-bundle": "^5.3",
         "hashids/hashids": "^3.0 || ^4.1"
     },
     "require-dev": {
@@ -49,7 +49,12 @@
     },
     "config": {
         "allow-plugins": {
-            "terminal42/contao-build-tools": true
+            "terminal42/contao-build-tools": true,
+            "contao-components/installer": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "contao-community-alliance/composer-plugin": true,
+            "contao/manager-plugin": true,
+            "php-http/discovery": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -49,12 +49,7 @@
     },
     "config": {
         "allow-plugins": {
-            "terminal42/contao-build-tools": true,
-            "contao-components/installer": true,
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "contao-community-alliance/composer-plugin": true,
-            "contao/manager-plugin": true,
-            "php-http/discovery": true
+            "terminal42/contao-build-tools": true
         }
     }
 }

--- a/config/services.yml
+++ b/config/services.yml
@@ -1,8 +1,8 @@
 services:
     Terminal42\ShortlinkBundle\Controller\ShortlinkController:
         arguments:
-            - '@contao.framework'
             - '@doctrine'
+            - '@contao.insert_tag.parser'
             - ~
         tags:
             - { name: controller.service_arguments }
@@ -14,7 +14,7 @@ services:
 
     Terminal42\ShortlinkBundle\EventListener\DataContainer\ShortlinkPermissionListener:
         arguments:
-            - '@security.token_storage'
+            - '@security.helper'
 
     Terminal42\ShortlinkBundle\EventListener\DataContainer\ShortlinkDateAddedListener:
         arguments:

--- a/contao/dca/tl_terminal42_shortlink.php
+++ b/contao/dca/tl_terminal42_shortlink.php
@@ -1,10 +1,11 @@
 <?php
 
-$GLOBALS['TL_DCA']['tl_terminal42_shortlink'] = [
+use Contao\DC_Table;
 
+$GLOBALS['TL_DCA']['tl_terminal42_shortlink'] = [
     // Config
     'config' => [
-        'dataContainer' => 'Table',
+        'dataContainer' => DC_Table::class,
         'enableVersioning' => true,
         'ctable' => ['tl_terminal42_shortlink_log'],
     ],

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -29,7 +29,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface
     {
         $loader->load(
             static function (ContainerBuilder $container): void {
-                $isNew = InstalledVersions::satisfies(new VersionParser(), 'symfony/doctrine-bridge', '^5.4');
+                $isNew = InstalledVersions::satisfies(new VersionParser(), 'symfony/doctrine-bridge', '>=5.4');
                 $bundleDir = $isNew ? 'src/Entity' : 'Entity';
 
                 $container->loadFromExtension('doctrine', [
@@ -43,7 +43,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface
                         ],
                     ],
                 ]);
-            }
+            },
         );
     }
 }

--- a/src/Controller/ShortlinkController.php
+++ b/src/Controller/ShortlinkController.php
@@ -6,6 +6,7 @@ namespace Terminal42\ShortlinkBundle\Controller;
 
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\InsertTags;
+use Contao\System;
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -16,8 +17,11 @@ use Terminal42\ShortlinkBundle\Entity\ShortlinkLog;
 
 class ShortlinkController
 {
-    public function __construct(private readonly ContaoFramework $framework, private readonly Registry $doctrine, private readonly bool $logIp)
-    {
+    public function __construct(
+        private readonly ContaoFramework $framework,
+        private readonly Registry $doctrine,
+        private readonly bool $logIp,
+    ) {
     }
 
     public function __invoke(Shortlink $_content, Request $request): Response
@@ -61,6 +65,6 @@ class ShortlinkController
 
         $target = str_replace('/{{(link(::|_[^:]+::)[^|}]+)}}/i', '{{$1|absolute}}', $target);
 
-        return \Contao\System::getContainer()->get('contao.insert_tag.parser')->replace($target);
+        return System::getContainer()->get('contao.insert_tag.parser')->replace($target);
     }
 }

--- a/src/Controller/ShortlinkController.php
+++ b/src/Controller/ShortlinkController.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Terminal42\ShortlinkBundle\Controller;
 
-use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\InsertTags;
-use Contao\System;
+use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -18,8 +16,8 @@ use Terminal42\ShortlinkBundle\Entity\ShortlinkLog;
 class ShortlinkController
 {
     public function __construct(
-        private readonly ContaoFramework $framework,
         private readonly Registry $doctrine,
+        private readonly InsertTagParser $insertTagParser,
         private readonly bool $logIp,
     ) {
     }
@@ -59,12 +57,8 @@ class ShortlinkController
             return $target;
         }
 
-        $this->framework->initialize();
-
-        $this->framework->createInstance(InsertTags::class);
-
         $target = str_replace('/{{(link(::|_[^:]+::)[^|}]+)}}/i', '{{$1|absolute}}', $target);
 
-        return System::getContainer()->get('contao.insert_tag.parser')->replace($target);
+        return $this->insertTagParser->replace($target);
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,7 +13,6 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('terminal42_shortlink');
         $rootNode = $treeBuilder->getRootNode();
-
         $rootNode
             ->children()
                 ->scalarNode('host')->defaultValue('')->end()

--- a/src/DependencyInjection/Terminal42ShortlinkExtension.php
+++ b/src/DependencyInjection/Terminal42ShortlinkExtension.php
@@ -17,7 +17,7 @@ class Terminal42ShortlinkExtension extends ConfigurableExtension
     {
         $loader = new YamlFileLoader(
             $container,
-            new FileLocator(__DIR__.'/../../config')
+            new FileLocator(__DIR__.'/../../config'),
         );
 
         $loader->load('services.yml');

--- a/src/Entity/Shortlink.php
+++ b/src/Entity/Shortlink.php
@@ -11,65 +11,47 @@ namespace Terminal42\ShortlinkBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Index;
+use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\Table;
 use Hashids\Hashids;
+use Terminal42\ShortlinkBundle\Repository\ShortlinkRepository;
 
-/**
- * @ORM\Table(
- *     name="tl_terminal42_shortlink",
- *     indexes={
- *         @ORM\Index(name="published", columns={"published","alias"})
- *     }
- * )
- * @ORM\Entity(repositoryClass="Terminal42\ShortlinkBundle\Repository\ShortlinkRepository")
- */
+#[Table(name: 'tl_terminal42_shortlink')]
+#[Index(name: 'published', columns: ['published', 'alias'])]
+#[Entity(repositoryClass: ShortlinkRepository::class)]
 class Shortlink
 {
-    /**
-     * @ORM\Column(type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
-     */
+    #[Column(type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[Id]
+    #[GeneratedValue(strategy: 'IDENTITY')]
     private int $id;
 
-    /**
-     * @ORM\Column(type="integer", nullable=false, options={"unsigned"=true, "default"=0})
-     */
+    #[Column(nullable: false, options: ['unsigned' => true, 'default' => 0])]
     private int $tstamp;
 
-    /**
-     * @ORM\Column(type="string", length=128, nullable=false, options={"default"=""})
-     */
+    #[Column(length: 128, nullable: false, options: ['default' => ''])]
     private string $alias;
 
-    /**
-     * @ORM\Column(type="string", length=255, nullable=false, options={"default"=""})
-     */
+    #[Column(length: 255, nullable: false, options: ['default' => ''])]
     private string $name;
 
-    /**
-     * @ORM\Column(type="text", nullable=true, length=65535)
-     */
-    private ?string $target = null;
+    #[Column(type: 'text', nullable: true, length: 65535)]
+    private string|null $target = null;
 
-    /**
-     * @ORM\Column(type="string", length=1, nullable=false, options={"fixed"=true, "default"=""})
-     */
+    #[Column(length: 1, nullable: false, options: ['fixed' => true, 'default' => ''])]
     private string $published;
 
-    /**
-     * @ORM\Column(type="integer", nullable=false, options={"unsigned"=true, "default"=0})
-     */
+    #[Column(nullable: false, options: ['unsigned' => true, 'default' => 0])]
     private int $dateAdded;
 
-    /**
-     * @ORM\OneToMany(targetEntity="Terminal42\ShortlinkBundle\Entity\ShortlinkLog", mappedBy="shortlink", fetch="EXTRA_LAZY", cascade={"persist","remove"})
-     */
+    #[OneToMany(targetEntity: ShortlinkLog::class, mappedBy: 'shortlink', fetch: 'EXTRA_LAZY', cascade: ['persist', 'remove'])]
     private Collection $logs;
 
-    /**
-     * Constructor.
-     */
     public function __construct()
     {
         $this->logs = new ArrayCollection();

--- a/src/Entity/ShortlinkLog.php
+++ b/src/Entity/ShortlinkLog.php
@@ -27,18 +27,18 @@ class ShortlinkLog
     /**
      * @ORM\Column(type="text", nullable=true, length=65535)
      */
-    private string $browser;
+    private string|null $browser;
 
     /**
      * @ORM\Column(type="string", nullable=true)
      */
-    private ?string $ip;
+    private string|null $ip;
 
     /**
      * @ORM\ManyToOne(targetEntity="Terminal42\ShortlinkBundle\Entity\Shortlink", inversedBy="logs")
      * @ORM\JoinColumn(name="pid", referencedColumnName="id", onDelete="CASCADE")
      */
-    private $shortlink;
+    private Shortlink|null $shortlink;
 
     /**
      * Constructor.

--- a/src/Entity/ShortlinkLog.php
+++ b/src/Entity/ShortlinkLog.php
@@ -4,48 +4,37 @@ declare(strict_types=1);
 
 namespace Terminal42\ShortlinkBundle\Entity;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\Table;
 
-/**
- * @ORM\Table(name="tl_terminal42_shortlink_log")
- * @ORM\Entity()
- */
+#[Table(name: 'tl_terminal42_shortlink_log')]
+#[Entity]
 class ShortlinkLog
 {
-    /**
-     * @ORM\Column(type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
-     */
+    #[Column(nullable: false, options: ['unsigned' => true])]
+    #[Id]
+    #[GeneratedValue(strategy: 'IDENTITY')]
     private int $id;
 
-    /**
-     * @ORM\Column(type="integer", nullable=false, options={"unsigned"=true})
-     */
+    #[Column(nullable: false, options: ['unsigned' => true])]
     private int $tstamp;
 
-    /**
-     * @ORM\Column(type="text", nullable=true, length=65535)
-     */
+    #[Column(type: 'text', nullable: true, length: 65535)]
     private string|null $browser;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    #[Column(type: 'string', nullable: true)]
     private string|null $ip;
 
-    /**
-     * @ORM\ManyToOne(targetEntity="Terminal42\ShortlinkBundle\Entity\Shortlink", inversedBy="logs")
-     * @ORM\JoinColumn(name="pid", referencedColumnName="id", onDelete="CASCADE")
-     */
-    private Shortlink|null $shortlink;
+    #[ManyToOne(targetEntity: Shortlink::class, inversedBy: 'logs')]
+    #[JoinColumn(name: 'pid', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    private Shortlink|null $shortlink = null;
 
-    /**
-     * Constructor.
-     *
-     * @param string $ip
-     */
-    public function __construct(string $browser, ?string $ip)
+    public function __construct(string $browser, string|null $ip)
     {
         $this->tstamp = time();
         $this->browser = $browser;

--- a/src/EventListener/DataContainer/ShortlinkDateAddedListener.php
+++ b/src/EventListener/DataContainer/ShortlinkDateAddedListener.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Terminal42\ShortlinkBundle\EventListener\DataContainer;
 
-use Contao\CoreBundle\ServiceAnnotation\Callback;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
 use Doctrine\DBAL\Connection;
 
-#[\Contao\CoreBundle\DependencyInjection\Attribute\AsCallback(table: 'tl_terminal42_shortlink', target: 'config.onsubmit')]
+#[AsCallback(table: 'tl_terminal42_shortlink', target: 'config.onsubmit')]
 class ShortlinkDateAddedListener
 {
     private const TABLE = 'tl_terminal42_shortlink';

--- a/src/EventListener/DataContainer/ShortlinkDateAddedListener.php
+++ b/src/EventListener/DataContainer/ShortlinkDateAddedListener.php
@@ -8,21 +8,16 @@ use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\DataContainer;
 use Doctrine\DBAL\Connection;
 
-/**
- * @Callback(table="tl_terminal42_shortlink", target="config.onsubmit")
- */
+#[\Contao\CoreBundle\DependencyInjection\Attribute\AsCallback(table: 'tl_terminal42_shortlink', target: 'config.onsubmit')]
 class ShortlinkDateAddedListener
 {
     private const TABLE = 'tl_terminal42_shortlink';
 
-    private Connection $connection;
-
-    public function __construct(Connection $connection)
+    public function __construct(private readonly Connection $connection)
     {
-        $this->connection = $connection;
     }
 
-    public function __invoke($dc): void
+    public function __invoke(mixed $dc): void
     {
         // Front end call
         if (!$dc instanceof DataContainer) {

--- a/src/EventListener/DataContainer/ShortlinkLabelListener.php
+++ b/src/EventListener/DataContainer/ShortlinkLabelListener.php
@@ -9,23 +9,16 @@ use Contao\DataContainer;
 use Doctrine\DBAL\Connection;
 use Terminal42\ShortlinkBundle\ShortlinkGenerator;
 
-/**
- * @Callback(table="tl_terminal42_shortlink", target="list.label.label")
- */
+#[\Contao\CoreBundle\DependencyInjection\Attribute\AsCallback(table: 'tl_terminal42_shortlink', target: 'list.label.label')]
 class ShortlinkLabelListener
 {
-    private Connection $connection;
-    private ShortlinkGenerator $generator;
+    private array|null $counts = null;
 
-    private ?array $counts = null;
-
-    public function __construct(Connection $connection, ShortlinkGenerator $generator)
+    public function __construct(private readonly Connection $connection, private readonly ShortlinkGenerator $generator)
     {
-        $this->connection = $connection;
-        $this->generator = $generator;
     }
 
-    public function __invoke(array $row, string $label, DataContainer $dc, array $columns)
+    public function __invoke(array $row, string $label, DataContainer $dc, array $columns): array
     {
         $url = $this->generator->generate((int) $row['id'], $row['alias'] ?? null);
 
@@ -34,7 +27,7 @@ class ShortlinkLabelListener
         $columns[1] = sprintf(
             '<a href="%s" target="_blank">%s</a>',
             $columns[1],
-            $row['name'] ?: $columns[1]
+            $row['name'] ?: $columns[1],
         );
 
         $columns[2] = $this->getLogCount((int) $row['id']);
@@ -46,7 +39,7 @@ class ShortlinkLabelListener
     {
         if (null === $this->counts) {
             $this->counts = $this->connection->fetchAllKeyValue(
-                'SELECT s.id, COUNT(l.id) FROM tl_terminal42_shortlink s LEFT JOIN tl_terminal42_shortlink_log l ON l.pid=s.id GROUP BY s.id'
+                'SELECT s.id, COUNT(l.id) FROM tl_terminal42_shortlink s LEFT JOIN tl_terminal42_shortlink_log l ON l.pid=s.id GROUP BY s.id',
             );
         }
 

--- a/src/EventListener/DataContainer/ShortlinkLabelListener.php
+++ b/src/EventListener/DataContainer/ShortlinkLabelListener.php
@@ -4,18 +4,20 @@ declare(strict_types=1);
 
 namespace Terminal42\ShortlinkBundle\EventListener\DataContainer;
 
-use Contao\CoreBundle\ServiceAnnotation\Callback;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
 use Doctrine\DBAL\Connection;
 use Terminal42\ShortlinkBundle\ShortlinkGenerator;
 
-#[\Contao\CoreBundle\DependencyInjection\Attribute\AsCallback(table: 'tl_terminal42_shortlink', target: 'list.label.label')]
+#[AsCallback(table: 'tl_terminal42_shortlink', target: 'list.label.label')]
 class ShortlinkLabelListener
 {
     private array|null $counts = null;
 
-    public function __construct(private readonly Connection $connection, private readonly ShortlinkGenerator $generator)
-    {
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly ShortlinkGenerator $generator,
+    ) {
     }
 
     public function __invoke(array $row, string $label, DataContainer $dc, array $columns): array

--- a/src/EventListener/DataContainer/ShortlinkPermissionListener.php
+++ b/src/EventListener/DataContainer/ShortlinkPermissionListener.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Terminal42\ShortlinkBundle\EventListener\DataContainer;
 
-use Contao\BackendUser;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\System;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
-#[\Contao\CoreBundle\DependencyInjection\Attribute\AsCallback(table: 'tl_terminal42_shortlink', target: 'config.onload')]
+#[AsCallback(table: 'tl_terminal42_shortlink', target: 'config.onload')]
 class ShortlinkPermissionListener
 {
     private const TABLE = 'tl_terminal42_shortlink';

--- a/src/EventListener/DataContainer/ShortlinkPermissionListener.php
+++ b/src/EventListener/DataContainer/ShortlinkPermissionListener.php
@@ -6,18 +6,20 @@ namespace Terminal42\ShortlinkBundle\EventListener\DataContainer;
 
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
-use Contao\System;
+use Symfony\Bundle\SecurityBundle\Security;
 
 #[AsCallback(table: 'tl_terminal42_shortlink', target: 'config.onload')]
 class ShortlinkPermissionListener
 {
     private const TABLE = 'tl_terminal42_shortlink';
 
+    public function __construct(private readonly Security $security)
+    {
+    }
+
     public function __invoke(): void
     {
-        $security = System::getContainer()->get('security.helper');
-
-        if ($security->isGranted(ContaoCorePermissions::USER_CAN_EDIT_FIELD_OF_TABLE, self::TABLE)) {
+        if ($this->security->isGranted(ContaoCorePermissions::USER_CAN_EDIT_FIELD_OF_TABLE, self::TABLE)) {
             return;
         }
 

--- a/src/EventListener/InsertTagsListener.php
+++ b/src/EventListener/InsertTagsListener.php
@@ -9,21 +9,14 @@ use Terminal42\ShortlinkBundle\Entity\Shortlink;
 use Terminal42\ShortlinkBundle\Repository\ShortlinkRepository;
 use Terminal42\ShortlinkBundle\ShortlinkGenerator;
 
-/**
- * @Hook("replaceInsertTags")
- */
+#[\Contao\CoreBundle\DependencyInjection\Attribute\AsHook('replaceInsertTags')]
 class InsertTagsListener
 {
-    private ShortlinkGenerator $generator;
-    private ShortlinkRepository $repository;
-
-    public function __construct(ShortlinkGenerator $generator, ShortlinkRepository $repository)
+    public function __construct(private readonly ShortlinkGenerator $generator, private readonly ShortlinkRepository $repository)
     {
-        $this->generator = $generator;
-        $this->repository = $repository;
     }
 
-    public function __invoke(string $tag)
+    public function __invoke(string $tag): string|bool
     {
         $chunks = explode('::', $tag);
 

--- a/src/EventListener/InsertTagsListener.php
+++ b/src/EventListener/InsertTagsListener.php
@@ -4,19 +4,21 @@ declare(strict_types=1);
 
 namespace Terminal42\ShortlinkBundle\EventListener;
 
-use Contao\CoreBundle\ServiceAnnotation\Hook;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
 use Terminal42\ShortlinkBundle\Entity\Shortlink;
 use Terminal42\ShortlinkBundle\Repository\ShortlinkRepository;
 use Terminal42\ShortlinkBundle\ShortlinkGenerator;
 
-#[\Contao\CoreBundle\DependencyInjection\Attribute\AsHook('replaceInsertTags')]
+#[AsHook('replaceInsertTags')]
 class InsertTagsListener
 {
-    public function __construct(private readonly ShortlinkGenerator $generator, private readonly ShortlinkRepository $repository)
-    {
+    public function __construct(
+        private readonly ShortlinkGenerator $generator,
+        private readonly ShortlinkRepository $repository,
+    ) {
     }
 
-    public function __invoke(string $tag): string|bool
+    public function __invoke(string $tag): bool|string
     {
         $chunks = explode('::', $tag);
 

--- a/src/Picker/ShortlinkPickerProvider.php
+++ b/src/Picker/ShortlinkPickerProvider.php
@@ -15,7 +15,7 @@ class ShortlinkPickerProvider extends AbstractInsertTagPickerProvider implements
         return 'shortlinkPicker';
     }
 
-    public function supportsContext($context): bool
+    public function supportsContext(string $context): bool
     {
         return 'link' === $context;
     }
@@ -25,7 +25,7 @@ class ShortlinkPickerProvider extends AbstractInsertTagPickerProvider implements
         return $this->isMatchingInsertTag($config);
     }
 
-    public function getDcaTable(): string
+    public function getDcaTable(PickerConfig|null $config = null): string
     {
         return 'tl_terminal42_shortlink';
     }
@@ -45,12 +45,12 @@ class ShortlinkPickerProvider extends AbstractInsertTagPickerProvider implements
         return $attributes;
     }
 
-    public function convertDcaValue(PickerConfig $config, $value): string
+    public function convertDcaValue(PickerConfig $config, mixed $value): string
     {
         return sprintf($this->getInsertTag($config), $value);
     }
 
-    protected function getRouteParameters(?PickerConfig $config = null): array
+    protected function getRouteParameters(PickerConfig|null $config = null): array
     {
         return ['do' => 'shortlink'];
     }

--- a/src/Repository/ShortlinkRepository.php
+++ b/src/Repository/ShortlinkRepository.php
@@ -14,8 +14,10 @@ class ShortlinkRepository extends ServiceEntityRepository
     /**
      * Constructor.
      */
-    public function __construct(ManagerRegistry $registry, private readonly Hashids $hashids)
-    {
+    public function __construct(
+        ManagerRegistry $registry,
+        private readonly Hashids $hashids,
+    ) {
         parent::__construct($registry, Shortlink::class);
     }
 

--- a/src/Repository/ShortlinkRepository.php
+++ b/src/Repository/ShortlinkRepository.php
@@ -11,16 +11,12 @@ use Terminal42\ShortlinkBundle\Entity\Shortlink;
 
 class ShortlinkRepository extends ServiceEntityRepository
 {
-    private Hashids $hashids;
-
     /**
      * Constructor.
      */
-    public function __construct(ManagerRegistry $registry, Hashids $hashids)
+    public function __construct(ManagerRegistry $registry, private readonly Hashids $hashids)
     {
         parent::__construct($registry, Shortlink::class);
-
-        $this->hashids = $hashids;
     }
 
     /**

--- a/src/Routing/RouteProvider.php
+++ b/src/Routing/RouteProvider.php
@@ -17,8 +17,12 @@ use Terminal42\ShortlinkBundle\ShortlinkGenerator;
 
 class RouteProvider implements RouteProviderInterface
 {
-    public function __construct(private readonly ShortlinkRepository $repository, private readonly ShortlinkGenerator $shortlinkGenerator, private readonly string $host, private readonly string|null $catchallRedirect)
-    {
+    public function __construct(
+        private readonly ShortlinkRepository $repository,
+        private readonly ShortlinkGenerator $shortlinkGenerator,
+        private readonly string $host,
+        private readonly string|null $catchallRedirect,
+    ) {
     }
 
     public function getRouteCollectionForRequest(Request $request): RouteCollection

--- a/src/Routing/RouteProvider.php
+++ b/src/Routing/RouteProvider.php
@@ -17,17 +17,8 @@ use Terminal42\ShortlinkBundle\ShortlinkGenerator;
 
 class RouteProvider implements RouteProviderInterface
 {
-    private ShortlinkRepository $repository;
-    private ShortlinkGenerator $shortlinkGenerator;
-    private string $host;
-    private ?string $catchallRedirect;
-
-    public function __construct(ShortlinkRepository $repository, ShortlinkGenerator $shortlinkGenerator, string $host, ?string $catchallRedirect)
+    public function __construct(private readonly ShortlinkRepository $repository, private readonly ShortlinkGenerator $shortlinkGenerator, private readonly string $host, private readonly string|null $catchallRedirect)
     {
-        $this->repository = $repository;
-        $this->host = $host;
-        $this->shortlinkGenerator = $shortlinkGenerator;
-        $this->catchallRedirect = $catchallRedirect;
     }
 
     public function getRouteCollectionForRequest(Request $request): RouteCollection
@@ -67,12 +58,12 @@ class RouteProvider implements RouteProviderInterface
         return $collection;
     }
 
-    public function getRouteByName($name): Route
+    public function getRouteByName(string $name): Route
     {
         throw new RouteNotFoundException('This router does not support routes by name');
     }
 
-    public function getRoutesByNames($names): array
+    public function getRoutesByNames(array|null $names = null): array
     {
         return [];
     }

--- a/src/ShortlinkGenerator.php
+++ b/src/ShortlinkGenerator.php
@@ -9,23 +9,16 @@ use Symfony\Component\Routing\RequestContext;
 
 class ShortlinkGenerator
 {
-    private Hashids $hashids;
-    private RequestContext $requestContext;
-    private string $host;
-
-    public function __construct(Hashids $hashids, RequestContext $requestContext, string $host)
+    public function __construct(private readonly Hashids $hashids, private readonly RequestContext $requestContext, private readonly string $host)
     {
-        $this->hashids = $hashids;
-        $this->requestContext = $requestContext;
-        $this->host = $host;
     }
 
-    public function generate(int $id, ?string $alias = null): string
+    public function generate(int $id, string|null $alias = null): string
     {
         return $this->requestContext->getScheme().'://'.rtrim($this->host ?: $this->requestContext->getHost(), '/').$this->generatePath($id, $alias);
     }
 
-    public function generatePath(int $id, ?string $alias = null): string
+    public function generatePath(int $id, string|null $alias = null): string
     {
         if (!$alias) {
             $alias = $this->hashids->encode($id);

--- a/src/ShortlinkGenerator.php
+++ b/src/ShortlinkGenerator.php
@@ -9,8 +9,11 @@ use Symfony\Component\Routing\RequestContext;
 
 class ShortlinkGenerator
 {
-    public function __construct(private readonly Hashids $hashids, private readonly RequestContext $requestContext, private readonly string $host)
-    {
+    public function __construct(
+        private readonly Hashids $hashids,
+        private readonly RequestContext $requestContext,
+        private readonly string $host,
+    ) {
     }
 
     public function generate(int $id, string|null $alias = null): string


### PR DESCRIPTION
This pull request adds compatibility for Contao 5.3. I also (kind of accidentally) ran Rector, and this added a couple changes since this pull request is dropping support for PHP 7.

I'm not sure if we could support Contao 4.13 and Contao 5.3 in the same source. If you think that's possible, i can try to do this. There might be more things we could strip if we only support Contao 5.3 (this check in src/ContaoManager/Plugin.php with the entity path, for example). I reverted some Rector changes in the Entity since PHP Attributes didn't work in my setup.