### PR TITLE
Improve QR code page in dark mode

### DIFF
--- a/contao/templates/be_shortlink_qr_code.html.twig
+++ b/contao/templates/be_shortlink_qr_code.html.twig
@@ -11,8 +11,8 @@
         <p>{{ 'MSC.shortlinkQrCode.explanation'|trans }}</p>
     </div>
 
-      <div class="tl_tbox" style="text-align:center;background-color:#f6f6f6">
-          <figure style="padding:13px 25px 0">
+      <div class="tl_tbox" style="text-align:center;background-color:#00000009;padding-block-start:24px;">
+          <figure style="padding:5px;background-color:#fefefe;display:inline-flex">
               {{ qrCode|raw }}
           </figure>
           <figcaption style="margin-top:18px;font-weight:bold"><a href="{{ url }}" target="_blank">{{ url }}</a></figcaption>


### PR DESCRIPTION
This PR improves the page on which the QR code for a shortlink is displayed in the backend.
In light mode there is basically no difference. In dark mode, there used to be a light background on the div containing the QR code. This also made the URL very difficult to read.
I have now changed it so that there is only a background behind the QR code itself and not on the entire container.
Here are some screenshots:

Before this change:
<img width="971" alt="before-light" src="https://github.com/user-attachments/assets/72cfb26a-dd10-449e-b97f-5b2c4fd80073">
<img width="980" alt="before-dark" src="https://github.com/user-attachments/assets/edb3e5db-1034-403e-a905-f29f777d2ed3">

After this change:
<img width="975" alt="after-light" src="https://github.com/user-attachments/assets/13d0c7a4-3377-402e-8964-1338c97d077f">
<img width="980" alt="after-dark" src="https://github.com/user-attachments/assets/5b7201dd-9e37-45ae-82cf-d8e1ce535868">

