### PR TITLE
Fix setting the absolute parameter to link insert tags for target URL

### DIFF
--- a/src/ShortlinkGenerator.php
+++ b/src/ShortlinkGenerator.php
@@ -39,7 +39,7 @@ class ShortlinkGenerator
             return $target;
         }
 
-        $target = preg_replace('/{{(link(::|_[^:]+::)[^|}]+)}}/i', '{{$1|absolute}}', $target);
+        $target = preg_replace('/{{(link(::|_[^:]+::)[^|}]+)}}/i', '{{$1::absolute}}', $target);
 
         return $this->insertTagParser->replace($target);
     }

--- a/src/ShortlinkGenerator.php
+++ b/src/ShortlinkGenerator.php
@@ -39,7 +39,7 @@ class ShortlinkGenerator
             return $target;
         }
 
-        $target = str_replace('/{{(link(::|_[^:]+::)[^|}]+)}}/i', '{{$1|absolute}}', $target);
+        $target = preg_replace('/{{(link(::|_[^:]+::)[^|}]+)}}/i', '{{$1|absolute}}', $target);
 
         return $this->insertTagParser->replace($target);
     }


### PR DESCRIPTION
`str_replace` doesn't do regex and the `|absolute` flag was removed in Contao 5. This PR fixes both issues.

CI failure seems unrelated, ran it locally, Rector only complained about `contao/dca/tl_terminal42_shortlink.php`.